### PR TITLE
feat(papers): add route and dynamic loading for papers by year in the…

### DIFF
--- a/InitialProject/src/app/Http/Controllers/HomeController.php
+++ b/InitialProject/src/app/Http/Controllers/HomeController.php
@@ -13,185 +13,43 @@ use RenanBr\BibTexParser\Processor;
 
 class HomeController extends Controller
 {
-
     public function index()
     {
-        //$papers = Paper::all()->orderBy, 'DESC');
-        $papers = [];
-        $year = range(Carbon::now()->year - 4, Carbon::now()->year);
-        //$papers =Paper::orderBy('paper_yearpub', 'desc')->where('paper_yearpub', '=', 1)->get();
         $years = range(Carbon::now()->year, Carbon::now()->year - 5);
-
         $from = Carbon::now()->year - 16;
         $to = Carbon::now()->year - 6;
-        // foreach ($years as $key => $value) {
-        //     $papers[$value] = Paper::where('paper_yearpub', '=', $value)->orderBy('paper_yearpub', 'desc')->get();
-        // }
-        //return gettype($papers);
-
-        // $p=Paper::with('author','teacher')->whereHas('teacher', function ($query) {
-        //     return $query->select(['fname_en','lname_en']);
-        // })->get();
-        $p2 = Paper::with([
-            'teacher' => function ($query) {
-                $query->select(DB::raw("CONCAT(concat(left(fname_en,1),'.'),' ',lname_en) as full_name"))->addSelect('user_papers.author_type');
-            },
-            'author' => function ($query) {
-                $query->select(DB::raw("CONCAT(concat(left(author_fname,1),'.'),' ',author_lname) as full_name"))->addSelect('author_of_papers.author_type');
-            },
-
-        ])->whereBetween('paper_yearpub', [$from, $to])->orderBy('paper_yearpub', 'desc')->get()->toArray();
-
-        $paper2 = array_map(function ($tag) {
-            $t = collect($tag['teacher']);
-            $a = collect($tag['author']);
-            $aut = $t->concat($a);
-            $aut = $aut->sortBy(['author_type', 'asc']);
-            //$ids = collect(['First author', 'Co-author', 'Corresponding author']);
-            $sorted = $aut->implode('full_name', ', ');
-            //return $sorted;
-            return array(
-                'id' => $tag['id'],
-                'author' => $sorted,
-                'paper_name' => $tag['paper_name'],
-                'paper_sourcetitle' => $tag['paper_sourcetitle'],
-                'paper_type' => $tag['paper_type'],
-                'paper_subtype' => $tag['paper_subtype'],
-                'paper_yearpub' => $tag['paper_yearpub'],
-                'paper_url' => $tag['paper_url'],
-                'paper_volume' => $tag['paper_volume'],
-                'paper_issue' => $tag['paper_issue'],
-                'paper_citation' => $tag['paper_citation'],
-                'paper_page' => $tag['paper_page'],
-                'paper_doi' => $tag['paper_doi'],
-            );
-        }, $p2);
-        //return $paper2;
-
-
-        foreach ($years as $key => $value) {
-            $p = Paper::with([
-                'teacher' => function ($query) {
-                    $query->select(DB::raw("CONCAT(concat(left(fname_en,1),'.'),' ',lname_en) as full_name"))->addSelect('user_papers.author_type');
-                },
-                'author' => function ($query) {
-                    $query->select(DB::raw("CONCAT(concat(left(author_fname,1),'.'),' ',author_lname) as full_name"))->addSelect('author_of_papers.author_type');
-                },
-
-            ])->where('paper_yearpub', '=', $value)->orderBy('paper_yearpub', 'desc')->get()->toArray();
-            //return $p;
-            $paper = array_map(function ($tag) {
-                $t = collect($tag['teacher']);
-                $a = collect($tag['author']);
-                $aut = $t->concat($a);
-                $aut = $aut->sortBy(['author_type', 'asc']);
-                //$ids = collect(['First author', 'Co-author', 'Corresponding author']);
-                $sorted = $aut->implode('full_name', ', ');
-                //return $sorted;
-                return array(
-                    'id' => $tag['id'],
-                    'author' => $sorted,
-                    'paper_name' => $tag['paper_name'],
-                    'paper_sourcetitle' => $tag['paper_sourcetitle'],
-                    'paper_type' => $tag['paper_type'],
-                    'paper_subtype' => $tag['paper_subtype'],
-                    'paper_yearpub' => $tag['paper_yearpub'],
-                    'paper_url' => $tag['paper_url'],
-                    'paper_volume' => $tag['paper_volume'],
-                    'paper_issue' => $tag['paper_issue'],
-                    'paper_citation' => $tag['paper_citation'],
-                    'paper_page' => $tag['paper_page'],
-                    'paper_doi' => $tag['paper_doi'],
-                );
-            }, $p);
-            $papers[$value] = collect($paper);
-        }
-        //$papers['Before '.$to] = collect($paper2);
-        $papers[$to] = collect($paper2);
-        //return $p;
-
-
-
-
-        //return $papers;
-        //return gettype($papers);
-        //return response()->json($years);
-        //$year = range(Carbon::now()->year-5, Carbon::now()->year);
-
-        //--------------- count by year-------------------//
-        $paper_tci = [];
-        $paper_scopus = [];
-        $paper_wos = [];
-
-        foreach ($year as $key => $value) {
-            $paper_scopus[] = Paper::whereHas('source', function ($query) {
-                return $query->where('source_data_id', '=', 1);
-            })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])
-                ->where(DB::raw('(paper_yearpub)'), $value)->count();
-        }
-        //return $paper_scopus;
-
-        foreach ($year as $key => $value) {
-            $paper_tci[] = Paper::whereHas('source', function ($query) {
-                return $query->where('source_data_id', '=', 3);
-            })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])
-                ->where(DB::raw('(paper_yearpub)'), $value)->count();
-        }
-
-        foreach ($year as $key => $value) {
-            $paper_wos[] = Paper::whereHas('source', function ($query) {
-                return $query->where('source_data_id', '=', 2);
-            })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])
-                ->where(DB::raw('(paper_yearpub)'), $value)->count();
-        }
-        //return $paper_tci;
-        //---------------------------------//
-
-        // $paper_scopus = Paper::whereHas('source', function ($query) {
-        //     return $query->where('source_data_id', '=', 1);
-        // })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
-
-
-        // //return $paper_scopus;
-
-
-        // $paper_tci = Paper::whereHas('source', function ($query) {
-        //     return $query->where('source_data_id', '=', 3);
-        // })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
-
-        //return $paper_tci;
-
-
-        // $paper_wos = Paper::whereHas('source', function ($query) {
-        //     return $query->where('source_data_id', '=', 2);
-        // })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
-
-        $num = $this->getnum();
-        $paper_tci_numall = $num['paper_tci'];
-        $paper_scopus_numall = $num['paper_scopus'];
-        $paper_wos_numall = $num['paper_wos'];
-        //return $paper_scopus_numall;
         
+        // Only get years for accordion headers, not the actual data
+        $papers = array_fill_keys($years, null);
+        $papers[$to] = null;
 
-        //$id = 0
+        $year = range(Carbon::now()->year - 4, Carbon::now()->year);
+        $num = $this->getnum();
+        
+        return view('home', compact('papers'))
+            ->with('year', json_encode($year, JSON_NUMERIC_CHECK))
+            ->with('paper_tci', json_encode($this->getYearlyPapers($year, 3), JSON_NUMERIC_CHECK))
+            ->with('paper_scopus', json_encode($this->getYearlyPapers($year, 1), JSON_NUMERIC_CHECK))
+            ->with('paper_wos', json_encode($this->getYearlyPapers($year, 2), JSON_NUMERIC_CHECK))
+            ->with('paper_tci_numall', json_encode($num['paper_tci'], JSON_NUMERIC_CHECK))
+            ->with('paper_scopus_numall', json_encode($num['paper_scopus'], JSON_NUMERIC_CHECK))
+            ->with('paper_wos_numall', json_encode($num['paper_wos'], JSON_NUMERIC_CHECK));
+    }
 
-        //$bb = $this->bibtex(2);
-
-        //$key="watchara";
-        //return response()->json($bb);
-        return view('home', compact('papers'))->with('year', json_encode($year, JSON_NUMERIC_CHECK))
-            ->with('paper_tci', json_encode($paper_tci, JSON_NUMERIC_CHECK))
-            ->with('paper_scopus', json_encode($paper_scopus, JSON_NUMERIC_CHECK))
-            ->with('paper_wos', json_encode($paper_wos, JSON_NUMERIC_CHECK))
-            ->with('paper_tci_numall', json_encode($paper_tci_numall, JSON_NUMERIC_CHECK))
-            ->with('paper_scopus_numall', json_encode($paper_scopus_numall, JSON_NUMERIC_CHECK))
-            ->with('paper_wos_numall', json_encode($paper_wos_numall, JSON_NUMERIC_CHECK));
-
-
-
-        // return $papers;
-        // (DB::raw('YEAR(paper_yearpub)')
-        //return view('home',compact('papers'));
+    private function getYearlyPapers($years, $sourceDataId)
+    {
+        $papers = [];
+        foreach ($years as $year) {
+            $count = Paper::whereHas('source', function ($query) use ($sourceDataId) {
+                return $query->where('source_data_id', '=', $sourceDataId);
+            })
+            ->whereIn('paper_type', ['Conference Proceeding', 'Journal'])
+            ->where('paper_yearpub', $year)
+            ->count();
+            
+            $papers[] = $count;
+        }
+        return $papers;
     }
 
     public function getnum()
@@ -200,23 +58,74 @@ class HomeController extends Controller
             return $query->where('source_data_id', '=', 1);
         })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
 
-
-        //return $paper_scopus;
-
-
         $paper_tci = Paper::whereHas('source', function ($query) {
             return $query->where('source_data_id', '=', 3);
         })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
-
-        //return $paper_tci;
-
 
         $paper_wos = Paper::whereHas('source', function ($query) {
             return $query->where('source_data_id', '=', 2);
         })->whereIn('paper_type', ['Conference Proceeding', 'Journal'])->count();
 
-        return compact('paper_scopus','paper_tci','paper_wos');
+        return compact('paper_scopus', 'paper_tci', 'paper_wos');
     }
+
+    public function getPapersByYear($year)
+    {
+        if ($year == Carbon::now()->year - 6) {
+            // Handle the "Before" section
+            $from = Carbon::now()->year - 16;
+            $to = Carbon::now()->year - 6;
+            $papers = $this->getPapersData(null, [$from, $to]);
+        } else {
+            // Handle regular years
+            $papers = $this->getPapersData($year);
+        }
+        
+        return response()->json($papers);
+    }
+
+    private function getPapersData($year = null, $range = null)
+    {
+        $query = Paper::with([
+            'teacher' => function ($query) {
+                $query->select(DB::raw("CONCAT(concat(left(fname_en,1),'.'),' ',lname_en) as full_name"))
+                      ->addSelect('user_papers.author_type');
+            },
+            'author' => function ($query) {
+                $query->select(DB::raw("CONCAT(concat(left(author_fname,1),'.'),' ',author_lname) as full_name"))
+                      ->addSelect('author_of_papers.author_type');
+            }
+        ]);
+
+        if ($range) {
+            $query->whereBetween('paper_yearpub', $range);
+        } else {
+            $query->where('paper_yearpub', '=', $year);
+        }
+
+        $papers = $query->orderBy('paper_yearpub', 'desc')->get()->toArray();
+
+        return array_map(function ($tag) {
+            $t = collect($tag['teacher']);
+            $a = collect($tag['author']);
+            $aut = $t->concat($a);
+            $aut = $aut->sortBy(['author_type', 'asc']);
+            $sorted = $aut->implode('full_name', ', ');
+            
+            return [
+                'id' => $tag['id'],
+                'author' => $sorted,
+                'paper_name' => $tag['paper_name'],
+                'paper_sourcetitle' => $tag['paper_sourcetitle'],
+                'paper_type' => $tag['paper_type'],
+                'paper_volume' => $tag['paper_volume'],
+                'paper_yearpub' => $tag['paper_yearpub'],
+                'paper_url' => $tag['paper_url'],
+                'paper_doi' => $tag['paper_doi']
+            ];
+        }, $papers);
+    }
+
     public function bibtex($id)
     {
         $paper = Paper::with(['author' => function ($query) {
@@ -227,13 +136,10 @@ class HomeController extends Controller
         require_once $Path['lib'] . 'lib_bibtex.inc.php';
 
         $Site = array();
-
-
         $Site['bibtex'] = new Bibtex('references.bib');
         $bb = $Site['bibtex'];
 
         $title = $paper['paper_name'];
-
         $a = collect($paper['author']);
         $author = $a->implode('author_name', ', ');
         $journal = $paper['paper_sourcetitle'];
@@ -244,7 +150,18 @@ class HomeController extends Controller
         $doi = $paper['paper_doi'];
 
         $key = "kku";
-        $arr = array("type" => $type, "key" => "kku", "author" => $author, "title" => $title, "journal" => $journal, "volume" => $volume, "number" => $number, 'year' => $year, 'pages' => $page, 'ee' => $doi);
+        $arr = array(
+            "type" => $type, 
+            "key" => "kku", 
+            "author" => $author, 
+            "title" => $title, 
+            "journal" => $journal, 
+            "volume" => $volume, 
+            "number" => $number, 
+            'year' => $year, 
+            'pages' => $page, 
+            'ee' => $doi
+        );
 
         $bb->bibarr["kku"] = $arr;
         $key = "kku";

--- a/InitialProject/src/routes/web.php
+++ b/InitialProject/src/routes/web.php
@@ -73,6 +73,7 @@ Route::middleware(['middleware' => 'PreventBackHistory'])->group(function () {
 
 
 Route::get('/', [App\Http\Controllers\HomeController::class, 'index'])->name('home');
+Route::get('/papers/{year}', [HomeController::class, 'getPapersByYear']);
 Route::get('/researchers', [ResearcherController::class, 'index'])->name('researchers.index');
 // Route::get('/researchers/{id}', [ResearcherController::class, 'request'])->name('researchers.request');
 Route::get('/researchers/{id}/search', [ResearcherController::class, 'search'])->name('searchresearchers');


### PR DESCRIPTION
This pull request includes significant changes to the `HomeController` class, improving the handling of paper data and optimizing the loading process in the `home.blade.php` view. The changes also include the addition of new routes in `web.php`.

### Changes to `HomeController`:

* Refactored the `index` method to simplify the logic and improve readability. Added helper methods to handle fetching paper data and counting papers by year.
* Added the `getPapersByYear` method to handle fetching papers dynamically based on the selected year.
* Introduced the `getPapersData` method to encapsulate the logic for fetching paper data, used by both `index` and `getPapersByYear` methods.

### Changes to `home.blade.php`:

* Modified the accordion section to load paper data dynamically when a year is selected, improving page performance. Added a loading spinner to indicate data fetching.

### Changes to `web.php`:

* Added a new route to handle AJAX requests for fetching papers by year.… home view