### PR TITLE
feat(deployment): update CPanel configuration to use move instead of …

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -23,21 +23,21 @@ deployment:
     - /bin/rm -f $PUBLICPATH/package-lock.json
 
     # ย้ายไฟล์ทั้งหมดจาก src ไปยัง public_html 
-    - /bin/cp -R $SRCPATH/* $PUBLICPATH/
-    
+    - /bin/mv $SRCPATH/* $PUBLICPATH/
+
     # ย้ายไฟล์ซ่อน
-    - /bin/cp $SRCPATH/.env* $PUBLICPATH/
-    - /bin/cp $SRCPATH/.htaccess $PUBLICPATH/
-    
+    - /bin/mv $SRCPATH/.env* $PUBLICPATH/
+    - /bin/mv $SRCPATH/.htaccess $PUBLICPATH/
+
     # ติดตั้ง dependencies
     - cd $PUBLICPATH
     - /opt/cpanel/composer/bin/composer install --no-dev
     - /opt/cpanel/composer/bin/composer dump-autoload -o
-    
+
     # ตั้งค่าสิทธิ์
     - /bin/chmod 755 $PUBLICPATH/storage -R
     - /bin/chmod 755 $PUBLICPATH/bootstrap/cache -R
-    
+
     # อัพเดท Laravel
     - /bin/php $PUBLICPATH/artisan key:generate
     - /bin/php $PUBLICPATH/artisan storage:link


### PR DESCRIPTION
This pull request includes a change to the deployment process in the `.cpanel.yml` file. The change modifies the commands used to move files from the source directory to the public directory.

Deployment process update:

* [`.cpanel.yml`](diffhunk://#diff-1d0159592208037d9e888933efb236b89cd4552bd963bbe9dfeae1cc5b2b719dL26-R30): Changed file transfer commands from `cp` (copy) to `mv` (move) for both regular and hidden files during deployment.…copy for file transfers